### PR TITLE
Correctly parse upper case letters in text portions of command

### DIFF
--- a/backend/smashbot.py
+++ b/backend/smashbot.py
@@ -223,7 +223,7 @@ class SmashBot():
         if command.lower().startswith('me over '):
             winner = poster
             loser = self.parse_first_slack_id(command)
-        elif command.startswith('<@') and command.lower().index('over me') > 0:
+        elif command.startswith('<@') and command.lower().find('over me') > 0:
             winner = self.parse_first_slack_id(command)
             loser = poster
         elif isAdmin and command.startswith('<@'):

--- a/backend/smashbot.py
+++ b/backend/smashbot.py
@@ -220,10 +220,10 @@ class SmashBot():
     def parse_message(self, command, poster):
         isAdmin = poster == bot_config.get_commissioner_slack_id()
 
-        if command.startswith('me over '):
+        if command.lower().startswith('me over '):
             winner = poster
             loser = self.parse_first_slack_id(command)
-        elif command.startswith('<@') and command.index('over me') > 0:
+        elif command.startswith('<@') and command.lower().index('over me') > 0:
             winner = self.parse_first_slack_id(command)
             loser = poster
         elif isAdmin and command.startswith('<@'):


### PR DESCRIPTION
This PR adds `.lower()` to the command passed to the bot, so that upper cased commands work correctly. This PR aims to fix this from happening:
![image](https://user-images.githubusercontent.com/2412116/66585479-86049580-eb4c-11e9-8923-8f1398d4216b.png)
Somebody sends a command with upper case "Me" and it fails. This should pass after these changes.

I didn't test this change locally because I'm not exactly sure how to get it up and running, but I figure that the changes are small enough that they're safe. I created this codepen to verify that the new code works as expected: https://ideone.com/ZLDT6O